### PR TITLE
etc: fix wrong repl path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ There are a few `.smt2` examples available within the `examples` dir.
 
 ## Chrobelias REPL
 
-Chrobelias offers CLI REPL for experimenting. It allows defining predicates, proving theorems, and visualizing the automaton the solver builds. By default opam builds an executable in `./_build/default/bin/chro.exe`. Starting it up brings you to REPL for evaluating theorem proving. We strongly encourage you to run it the following way.
+Chrobelias offers CLI REPL for experimenting. It allows defining predicates, proving theorems, and visualizing the automaton the solver builds. By default opam builds an executable in `./_build/default/bin/chro_repl.exe`. Starting it up brings you to REPL for evaluating theorem proving. We strongly encourage you to run it the following way.
 
 ```bash
 ledit ./_build/default/bin/chro_repl.exe

--- a/examples/fcp_7_11_with_exps.smt2
+++ b/examples/fcp_7_11_with_exps.smt2
@@ -1,0 +1,11 @@
+(set-info :smt-lib-version 2.6)
+(set-logic ALL)
+(set-info :status sat)
+
+(declare-fun P () Int)
+(declare-fun x () Int)
+; P = 59 (answer to Frobenius coin problem with 7 11), 2^x - 5 = 59, x = 8
+(assert (= (+ 5 P) (exp 2 x)))
+(assert (and (<= 0 P) (forall ((x0 Int) (x1 Int)) (=> (and (<= 0 x0) (<= 0 x1)) (not (= (+ (* x0 7) (* x1 11)) P)))) (forall ((R Int)) (=> (forall ((x0 Int) (x1 Int)) (=> (and (<= 0 x0) (<= 0 x1)) (not (= (+ (* x0 7) (* x1 11)) R)))) (<= R P)))))
+(check-sat)
+(exit)


### PR DESCRIPTION
This patchset fixes repl executable name from `chro.exe` to
`chro_repl.exe` in readme. And adds missing `fcp_7_11_with_exps.smt2`
tests that is an example of combination of LIA with QF_EIA.
